### PR TITLE
Restore translated titles of sidebar

### DIFF
--- a/src/sidebarLearn.json
+++ b/src/sidebarLearn.json
@@ -52,23 +52,23 @@
       "path": "/learn/describing-the-ui",
       "routes": [
         {
-          "title": "Your First Component",
+          "title": "初めてのコンポーネント",
           "path": "/learn/your-first-component"
         },
         {
-          "title": "Importing and Exporting Components",
+          "title": "コンポーネントのインポートとエクスポート",
           "path": "/learn/importing-and-exporting-components"
         },
         {
-          "title": "Writing Markup with JSX",
+          "title": "JSX でマークアップを記述する",
           "path": "/learn/writing-markup-with-jsx"
         },
         {
-          "title": "JavaScript in JSX with Curly Braces",
+          "title": "JSX に波括弧で JavaScript を含める",
           "path": "/learn/javascript-in-jsx-with-curly-braces"
         },
         {
-          "title": "Passing Props to a Component",
+          "title": "コンポーネントに props を渡す",
           "path": "/learn/passing-props-to-a-component"
         },
         {


### PR DESCRIPTION
翻訳済み記事のサイドバーのタイトルを復活させました
