### PR TITLE
Missing translation in the sidebar (Synchronizing with Effect)

### DIFF
--- a/src/sidebarLearn.json
+++ b/src/sidebarLearn.json
@@ -169,7 +169,7 @@
           "path": "/learn/manipulating-the-dom-with-refs"
         },
         {
-          "title": "Synchronizing with Effects",
+          "title": "エフェクトを使って同期を行う",
           "path": "/learn/synchronizing-with-effects"
         },
         {


### PR DESCRIPTION
https://ja.react.dev/learn/synchronizing-with-effects

のサイドメニューが翻訳されていなかったので翻訳しました。

<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/ja.reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->
