### PR TITLE
Tweak font settings for windows environment; `system-ui` (Yu Gothic UI) to `BIZ UD Gothic`

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -69,11 +69,17 @@ module.exports = {
         display: [
           'Optimistic Display',
           '-apple-system',
+          // In Windows, font which is suitable for long text should be selected
+          // for Japanese characters instead of Yu Gothic UI (system-ui)
+          '"BIZ UDGothic"',
+          'Meiryo',
           ...defaultTheme.fontFamily.sans,
         ],
         text: [
           'Optimistic Text',
           '-apple-system',
+          '"BIZ UDGothic"',
+          'Meiryo',
           ...defaultTheme.fontFamily.sans,
         ],
         mono: ['"Source Code Pro"', ...defaultTheme.fontFamily.mono],


### PR DESCRIPTION
<!--

Thank you for the PR! Contributors like you keep React awesome!

Please see the Contribution Guide for guidelines:

https://github.com/reactjs/ja.reactjs.org/blob/main/CONTRIBUTING.md

If your PR references an existing issue, please add the issue number below

-->

fixes #639

> Mac で閲覧するときには無難なフォント (少なくとも私の環境では Hiragino Kaku Gothic ProN) が選ばれますが、Windows (少なくとも windows 11 では)の場合には本文が Yu Gothic UI になっているのが気になります。

日本語話者が Windows 10 / 11 を使ってブラウジングする標準的な環境において、上記のような問題があるため、フォント設定を調整した。

## 欧文について

Optimistic Display / Text というのが恐らく、 Meta 社のコーポレートフォント？のようなもので、欧文をカバーしている様子。これは優先度が最も高いので、**未翻訳の英文、本文中の英単語** の見え方は保つことができているはず。

## Mac 環境について

`-apple-system`  を使って、よしなにフォントを調整してくれているはずなので、 Mac 環境では、これ以降の BIZ UD ゴシック, メイリオの設定を無視して、変わらずフォントを設定してくれているはず。

## 和文フォントの選定

BIZ UD ゴシック (P ではない) を、その次の優先度で設定している。 

### 標準設定 `sans-serif` ではない理由
  - この場合、Windows でデフォルト設定のまま使用している環境では、カスカスの游ゴシックが表示され、読みづらいし貧相な見た目になる

### メイリオの優先度を下げた理由

- 文字が大きすぎて読みづらい
  - 英字に合わせて font-size の設定値が大きめ (17px) 
  - このフォント自体が、すこし大きめの作りになっている？
- Twitter, Zenn, Qiita で採用されているので見慣れているものの、やはりフォントが大きいと違和感がある
- 一部の環境で BIZ UD Gothic がインストールされていない可能性も考え、その次の優先度で設定した

### BIZ フォントを選択した理由

- ICS も採用している https://ics.media/entry/200317/
- メイリオよりも締まりのある見た目なので、 17px であっても読みやすい
  - (私が設定してこのフォントをデフォルトにしているので、見慣れすぎて過大評価しているかも...)
  - (あまり有名じゃないので、見慣れない人もいる...？)


### `BIZ UDP Gothic` ではなく `BIZ UD Gothic` を選んだ理由

- 欧文は Optimistic が最高優先度なので、欧文が不格好になる心配がない
- UDP のほうは、文の切れ目が分かりづらく、読むのに疲れる
  - 約物が半角サイズなので、句読点と次の文の頭のあいだのスペースが無いため。

## その他

デフォルトの設定は、上記よりも低い優先度でそのままにした。マイナーな環境であっても、最低限適切なフォントが使えたほうが良いはずなので。


## デグレがないか、ざっと自主確認

Windows では BIZ UDGothic に変わる、その他の環境では変わらない

- [x] Windows 11, version 22H2, Google Chrome
- [x] Mac, Ventura 13.4.1 (c), Google Chrome
- [x] Mac, Safari
- [x] iPad, Safari
- [x] iPad, Google Chrome
- [x] Android 12, Google Chrome 


