### PR TITLE
Fix top page layout

### DIFF
--- a/src/components/Layout/HomeContent.js
+++ b/src/components/Layout/HomeContent.js
@@ -49,8 +49,9 @@ function Section({children, background = null}) {
 }
 
 function Header({children}) {
+  // "lg:max-w-xl" has been removed in Japanese version
   return (
-    <h2 className="leading-xl font-display text-primary dark:text-primary-dark font-semibold text-5xl lg:text-6xl -mt-4 mb-7 w-full max-w-3xl lg:max-w-xl">
+    <h2 className="leading-xl font-display text-primary dark:text-primary-dark font-semibold text-5xl lg:text-6xl -mt-4 mb-7 w-full max-w-3xl">
       {children}
     </h2>
   );


### PR DESCRIPTION
#645 に関連して、トップページの見出しのレイアウトが PC 版レイアウトのときに崩れてしまっていたので調整しました。
翻訳は変えずに問題を起こしていたクラスを取り除いています。

昔：

<img width="385" alt="image" src="https://github.com/reactjs/ja.react.dev/assets/7779406/f2dae7ef-51db-4c4d-828c-1cea62f7c9f6">

フォント入れ替え後：

<img width="494" alt="image" src="https://github.com/reactjs/ja.react.dev/assets/7779406/90728fa1-81ce-413b-89fa-a5b38e6e1805">

今回の調整後：

<img width="539" alt="image" src="https://github.com/reactjs/ja.react.dev/assets/7779406/4beb6c1c-0782-4dab-83c0-a85dffab3fcb">
