### PR TITLE
Update legacy warnings and redirect URLs

### DIFF
--- a/content/blog/2013-06-02-jsfiddle-integration.md
+++ b/content/blog/2013-06-02-jsfiddle-integration.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-06-05-why-react.md
+++ b/content/blog/2013-06-05-why-react.md
@@ -5,7 +5,7 @@ author: [petehunt]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-06-12-community-roundup.md
+++ b/content/blog/2013-06-12-community-roundup.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-06-19-community-roundup-2.md
+++ b/content/blog/2013-06-19-community-roundup-2.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-06-21-react-v0-3-3.md
+++ b/content/blog/2013-06-21-react-v0-3-3.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-06-27-community-roundup-3.md
+++ b/content/blog/2013-06-27-community-roundup-3.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-07-02-react-v0-4-autobind-by-default.md
+++ b/content/blog/2013-07-02-react-v0-4-autobind-by-default.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-07-03-community-roundup-4.md
+++ b/content/blog/2013-07-03-community-roundup-4.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-07-11-react-v0-4-prop-validation-and-default-values.md
+++ b/content/blog/2013-07-11-react-v0-4-prop-validation-and-default-values.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-07-17-react-v0-4-0.md
+++ b/content/blog/2013-07-17-react-v0-4-0.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-07-23-community-roundup-5.md
+++ b/content/blog/2013-07-23-community-roundup-5.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-07-26-react-v0-4-1.md
+++ b/content/blog/2013-07-26-react-v0-4-1.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-07-30-use-react-and-jsx-in-ruby-on-rails.md
+++ b/content/blog/2013-07-30-use-react-and-jsx-in-ruby-on-rails.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-08-05-community-roundup-6.md
+++ b/content/blog/2013-08-05-community-roundup-6.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-08-19-use-react-and-jsx-in-python-applications.md
+++ b/content/blog/2013-08-19-use-react-and-jsx-in-python-applications.md
@@ -5,7 +5,7 @@ author: [kmeht]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-08-26-community-roundup-7.md
+++ b/content/blog/2013-08-26-community-roundup-7.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-09-24-community-roundup-8.md
+++ b/content/blog/2013-09-24-community-roundup-8.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-10-16-react-v0.5.0.md
+++ b/content/blog/2013-10-16-react-v0.5.0.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-10-29-react-v0-5-1.md
+++ b/content/blog/2013-10-29-react-v0-5-1.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-10-3-community-roundup-9.md
+++ b/content/blog/2013-10-3-community-roundup-9.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-11-06-community-roundup-10.md
+++ b/content/blog/2013-11-06-community-roundup-10.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-11-18-community-roundup-11.md
+++ b/content/blog/2013-11-18-community-roundup-11.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-12-18-react-v0.5.2-v0.4.2.md
+++ b/content/blog/2013-12-18-react-v0.5.2-v0.4.2.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-12-19-react-v0.8.0.md
+++ b/content/blog/2013-12-19-react-v0.8.0.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-12-23-community-roundup-12.md
+++ b/content/blog/2013-12-23-community-roundup-12.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2013-12-30-community-roundup-13.md
+++ b/content/blog/2013-12-30-community-roundup-13.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-01-02-react-chrome-developer-tools.md
+++ b/content/blog/2014-01-02-react-chrome-developer-tools.md
@@ -5,7 +5,7 @@ author: [sebmarkbage]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-01-06-community-roundup-14.md
+++ b/content/blog/2014-01-06-community-roundup-14.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-02-05-community-roundup-15.md
+++ b/content/blog/2014-02-05-community-roundup-15.md
@@ -5,7 +5,7 @@ author: [jgebhardt]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-02-15-community-roundup-16.md
+++ b/content/blog/2014-02-15-community-roundup-16.md
@@ -5,7 +5,7 @@ author: [jgebhardt]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-02-16-react-v0.9-rc1.md
+++ b/content/blog/2014-02-16-react-v0.9-rc1.md
@@ -5,7 +5,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-02-20-react-v0.9.md
+++ b/content/blog/2014-02-20-react-v0.9.md
@@ -5,7 +5,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-02-24-community-roundup-17.md
+++ b/content/blog/2014-02-24-community-roundup-17.md
@@ -5,7 +5,7 @@ author: [jgebhardt]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-03-14-community-roundup-18.md
+++ b/content/blog/2014-03-14-community-roundup-18.md
@@ -5,7 +5,7 @@ author: [jgebhardt]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-03-19-react-v0.10-rc1.md
+++ b/content/blog/2014-03-19-react-v0.10-rc1.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-03-21-react-v0.10.md
+++ b/content/blog/2014-03-21-react-v0.10.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-03-28-the-road-to-1.0.md
+++ b/content/blog/2014-03-28-the-road-to-1.0.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-04-04-reactnet.md
+++ b/content/blog/2014-04-04-reactnet.md
@@ -5,7 +5,7 @@ author: [Daniel15]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-05-06-flux.md
+++ b/content/blog/2014-05-06-flux.md
@@ -5,7 +5,7 @@ author: [fisherwebdev, jingc]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-05-29-one-year-of-open-source-react.md
+++ b/content/blog/2014-05-29-one-year-of-open-source-react.md
@@ -5,7 +5,7 @@ author: [chenglou]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-06-27-community-roundup-19.md
+++ b/content/blog/2014-06-27-community-roundup-19.md
@@ -5,7 +5,7 @@ author: [chenglou]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-07-13-react-v0.11-rc1.md
+++ b/content/blog/2014-07-13-react-v0.11-rc1.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-07-17-react-v0.11.md
+++ b/content/blog/2014-07-17-react-v0.11.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-07-25-react-v0.11.1.md
+++ b/content/blog/2014-07-25-react-v0.11.1.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-07-28-community-roundup-20.md
+++ b/content/blog/2014-07-28-community-roundup-20.md
@@ -5,7 +5,7 @@ author: [LoukaN]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-07-30-flux-actions-and-the-dispatcher.md
+++ b/content/blog/2014-07-30-flux-actions-and-the-dispatcher.md
@@ -5,7 +5,7 @@ author: [fisherwebdev]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -19,7 +19,7 @@ Where the Dispatcher Fits in the Flux Data Flow
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -31,7 +31,7 @@ Actions and ActionCreators
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -49,7 +49,7 @@ Why We Need a Dispatcher
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -67,7 +67,7 @@ Example Chat App
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-08-03-community-roundup-21.md
+++ b/content/blog/2014-08-03-community-roundup-21.md
@@ -5,7 +5,7 @@ author: [LoukaN]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-09-03-introducing-the-jsx-specification.md
+++ b/content/blog/2014-09-03-introducing-the-jsx-specification.md
@@ -5,7 +5,7 @@ author: [sebmarkbage]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-09-12-community-round-up-22.md
+++ b/content/blog/2014-09-12-community-round-up-22.md
@@ -6,7 +6,7 @@ author: [LoukaN]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-09-16-react-v0.11.2.md
+++ b/content/blog/2014-09-16-react-v0.11.2.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-09-24-testing-flux-applications.md
+++ b/content/blog/2014-09-24-testing-flux-applications.md
@@ -5,7 +5,7 @@ author: [fisherwebdev]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-10-14-introducing-react-elements.md
+++ b/content/blog/2014-10-14-introducing-react-elements.md
@@ -7,7 +7,7 @@ redirect_from:
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-10-16-react-v0.12-rc1.md
+++ b/content/blog/2014-10-16-react-v0.12-rc1.md
@@ -5,7 +5,7 @@ author: [sebmarkbage]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-10-17-community-roundup-23.md
+++ b/content/blog/2014-10-17-community-roundup-23.md
@@ -6,7 +6,7 @@ author: [LoukaN]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-10-27-react-js-conf.md
+++ b/content/blog/2014-10-27-react-js-conf.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-10-28-react-v0.12.md
+++ b/content/blog/2014-10-28-react-v0.12.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-11-24-react-js-conf-updates.md
+++ b/content/blog/2014-11-24-react-js-conf-updates.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-11-25-community-roundup-24.md
+++ b/content/blog/2014-11-25-community-roundup-24.md
@@ -6,7 +6,7 @@ author: [steveluscher]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-12-18-react-v0.12.2.md
+++ b/content/blog/2014-12-18-react-v0.12.2.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2014-12-19-react-js-conf-diversity-scholarship.md
+++ b/content/blog/2014-12-19-react-js-conf-diversity-scholarship.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-01-27-react-v0.13.0-beta-1.md
+++ b/content/blog/2015-01-27-react-v0.13.0-beta-1.md
@@ -5,7 +5,7 @@ author: [sebmarkbage]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-02-18-react-conf-roundup-2015.md
+++ b/content/blog/2015-02-18-react-conf-roundup-2015.md
@@ -6,7 +6,7 @@ author: [steveluscher]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-02-20-introducing-relay-and-graphql.md
+++ b/content/blog/2015-02-20-introducing-relay-and-graphql.md
@@ -6,7 +6,7 @@ author: [wincent]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-02-24-react-v0.13-rc1.md
+++ b/content/blog/2015-02-24-react-v0.13-rc1.md
@@ -6,7 +6,7 @@ date: 2015-02-24 14:00
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-02-24-streamlining-react-elements.md
+++ b/content/blog/2015-02-24-streamlining-react-elements.md
@@ -6,7 +6,7 @@ date: 2015-02-24 11:00
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-03-03-react-v0.13-rc2.md
+++ b/content/blog/2015-03-03-react-v0.13-rc2.md
@@ -5,7 +5,7 @@ author: [sebmarkbage]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-03-04-community-roundup-25.md
+++ b/content/blog/2015-03-04-community-roundup-25.md
@@ -6,7 +6,7 @@ author: [matthewjohnston4]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-03-10-react-v0.13.md
+++ b/content/blog/2015-03-10-react-v0.13.md
@@ -5,7 +5,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-03-16-react-v0.13.1.md
+++ b/content/blog/2015-03-16-react-v0.13.1.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-03-19-building-the-facebook-news-feed-with-relay.md
+++ b/content/blog/2015-03-19-building-the-facebook-news-feed-with-relay.md
@@ -5,7 +5,7 @@ author: [josephsavona]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-03-26-introducing-react-native.md
+++ b/content/blog/2015-03-26-introducing-react-native.md
@@ -5,7 +5,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-03-30-community-roundup-26.md
+++ b/content/blog/2015-03-30-community-roundup-26.md
@@ -6,7 +6,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-04-17-react-native-v0.4.md
+++ b/content/blog/2015-04-17-react-native-v0.4.md
@@ -6,7 +6,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-04-18-react-v0.13.2.md
+++ b/content/blog/2015-04-18-react-v0.13.2.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-05-01-graphql-introduction.md
+++ b/content/blog/2015-05-01-graphql-introduction.md
@@ -5,7 +5,7 @@ author: [schrockn]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-05-08-react-v0.13.3.md
+++ b/content/blog/2015-05-08-react-v0.13.3.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-05-22-react-native-release-process.md
+++ b/content/blog/2015-05-22-react-native-release-process.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-06-12-deprecating-jstransform-and-react-tools.md
+++ b/content/blog/2015-06-12-deprecating-jstransform-and-react-tools.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-07-03-react-v0.14-beta-1.md
+++ b/content/blog/2015-07-03-react-v0.14-beta-1.md
@@ -5,7 +5,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-08-03-new-react-devtools-beta.md
+++ b/content/blog/2015-08-03-new-react-devtools-beta.md
@@ -5,7 +5,7 @@ author: [jaredly]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-08-11-relay-technical-preview.md
+++ b/content/blog/2015-08-11-relay-technical-preview.md
@@ -5,7 +5,7 @@ author: [josephsavona]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-08-13-reacteurope-roundup.md
+++ b/content/blog/2015-08-13-reacteurope-roundup.md
@@ -6,7 +6,7 @@ author: [matthewjohnston4]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-09-02-new-react-developer-tools.md
+++ b/content/blog/2015-09-02-new-react-developer-tools.md
@@ -6,7 +6,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-09-10-react-v0.14-rc1.md
+++ b/content/blog/2015-09-10-react-v0.14-rc1.md
@@ -5,7 +5,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-09-14-community-roundup-27.md
+++ b/content/blog/2015-09-14-community-roundup-27.md
@@ -6,7 +6,7 @@ author: [steveluscher]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-10-01-react-render-and-top-level-api.md
+++ b/content/blog/2015-10-01-react-render-and-top-level-api.md
@@ -5,7 +5,7 @@ author: ["jimfb", "sebmarkbage"]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-10-07-react-v0.14.md
+++ b/content/blog/2015-10-07-react-v0.14.md
@@ -5,7 +5,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-10-19-reactiflux-is-moving-to-discord.md
+++ b/content/blog/2015-10-19-reactiflux-is-moving-to-discord.md
@@ -5,7 +5,7 @@ author: [benigeri]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-10-28-react-v0.14.1.md
+++ b/content/blog/2015-10-28-react-v0.14.1.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-11-02-react-v0.14.2.md
+++ b/content/blog/2015-11-02-react-v0.14.2.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-11-18-react-v0.14.3.md
+++ b/content/blog/2015-11-18-react-v0.14.3.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-12-04-react-js-conf-2016-diversity-scholarship.md
+++ b/content/blog/2015-12-04-react-js-conf-2016-diversity-scholarship.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-12-16-ismounted-antipattern.md
+++ b/content/blog/2015-12-16-ismounted-antipattern.md
@@ -5,7 +5,7 @@ author: [jimfb]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-12-18-react-components-elements-and-instances.md
+++ b/content/blog/2015-12-18-react-components-elements-and-instances.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2015-12-29-react-v0.14.4.md
+++ b/content/blog/2015-12-29-react-v0.14.4.md
@@ -5,7 +5,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-01-08-A-implies-B-does-not-imply-B-implies-A.md
+++ b/content/blog/2016-01-08-A-implies-B-does-not-imply-B-implies-A.md
@@ -5,7 +5,7 @@ author: [jimfb]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-01-12-discontinuing-ie8-support.md
+++ b/content/blog/2016-01-12-discontinuing-ie8-support.md
@@ -5,7 +5,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-02-19-new-versioning-scheme.md
+++ b/content/blog/2016-02-19-new-versioning-scheme.md
@@ -5,7 +5,7 @@ author: [sebmarkbage]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-03-07-react-v15-rc1.md
+++ b/content/blog/2016-03-07-react-v15-rc1.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-03-16-react-v15-rc2.md
+++ b/content/blog/2016-03-16-react-v15-rc2.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-03-29-react-v0.14.8.md
+++ b/content/blog/2016-03-29-react-v0.14.8.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-04-07-react-v15.md
+++ b/content/blog/2016-04-07-react-v15.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-04-08-react-v15.0.1.md
+++ b/content/blog/2016-04-08-react-v15.0.1.md
@@ -5,7 +5,7 @@ author: [zpao]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-07-11-introducing-reacts-error-code-system.md
+++ b/content/blog/2016-07-11-introducing-reacts-error-code-system.md
@@ -5,7 +5,7 @@ author: [keyanzhang]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-07-13-mixins-considered-harmful.md
+++ b/content/blog/2016-07-13-mixins-considered-harmful.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-07-22-create-apps-with-no-configuration.md
+++ b/content/blog/2016-07-22-create-apps-with-no-configuration.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-08-05-relay-state-of-the-state.md
+++ b/content/blog/2016-08-05-relay-state-of-the-state.md
@@ -5,7 +5,7 @@ author: [josephsavona]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-09-28-our-first-50000-stars.md
+++ b/content/blog/2016-09-28-our-first-50000-stars.md
@@ -5,7 +5,7 @@ author: [vjeux]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2016-11-16-react-v15.4.0.md
+++ b/content/blog/2016-11-16-react-v15.4.0.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -102,7 +102,7 @@ You can learn more about snapshot testing in [this Jest blog post](https://faceb
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2017-04-07-react-v15.5.0.md
+++ b/content/blog/2017-04-07-react-v15.5.0.md
@@ -5,7 +5,7 @@ author: [acdlite]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -155,7 +155,7 @@ import { createRenderer } from 'react-test-renderer/shallow';
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -171,7 +171,7 @@ A special thank you to these folks for transferring ownership of npm package nam
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -216,7 +216,7 @@ We've also published version `15.5.0` of the `react`, `react-dom`, and addons pa
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2017-05-18-whats-new-in-create-react-app.md
+++ b/content/blog/2017-05-18-whats-new-in-create-react-app.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2017-06-13-react-v15.6.0.md
+++ b/content/blog/2017-06-13-react-v15.6.0.md
@@ -5,7 +5,7 @@ author: [flarnie]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -34,7 +34,7 @@ After the last release, we got valuable community feedback that deprecation warn
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -79,7 +79,7 @@ We've also published version `15.6.0` of `react` and `react-dom` on npm, and the
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2017-07-26-error-handling-in-react-16.md
+++ b/content/blog/2017-07-26-error-handling-in-react-16.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2017-09-08-dom-attributes-in-react-16.md
+++ b/content/blog/2017-09-08-dom-attributes-in-react-16.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2017-09-25-react-v15.6.2.md
+++ b/content/blog/2017-09-25-react-v15.6.2.md
@@ -5,7 +5,7 @@ author: [nhunzaker]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -54,7 +54,7 @@ We've also published version `15.6.2` of `react` and `react-dom` on npm, and the
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2017-09-26-react-v16.0.md
+++ b/content/blog/2017-09-26-react-v16.0.md
@@ -5,7 +5,7 @@ author: [acdlite]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
+++ b/content/blog/2017-11-28-react-v16.2.0-fragment-support.md
@@ -5,7 +5,7 @@ author: [clemmy]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2017-12-07-introducing-the-react-rfc-process.md
+++ b/content/blog/2017-12-07-introducing-the-react-rfc-process.md
@@ -5,7 +5,7 @@ author: [acdlite]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2017-12-15-improving-the-repository-infrastructure.md
+++ b/content/blog/2017-12-15-improving-the-repository-infrastructure.md
@@ -5,7 +5,7 @@ author: [gaearon, bvaughn]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-03-01-sneak-peek-beyond-react-16.md
+++ b/content/blog/2018-03-01-sneak-peek-beyond-react-16.md
@@ -5,7 +5,7 @@ author: [sophiebits]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-03-27-update-on-async-rendering.md
+++ b/content/blog/2018-03-27-update-on-async-rendering.md
@@ -5,7 +5,7 @@ author: [bvaughn]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -44,7 +44,7 @@ Learn more about this codemod on the [16.9.0 release post.](https://reactjs.org/
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-03-29-react-v-16-3.md
+++ b/content/blog/2018-03-29-react-v-16-3.md
@@ -5,7 +5,7 @@ author: [bvaughn]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-05-23-react-v-16-4.md
+++ b/content/blog/2018-05-23-react-v-16-4.md
@@ -5,7 +5,7 @@ author: [acdlite]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-06-07-you-probably-dont-need-derived-state.md
+++ b/content/blog/2018-06-07-you-probably-dont-need-derived-state.md
@@ -5,7 +5,7 @@ author: [bvaughn]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -214,7 +214,7 @@ Refs can be useful in certain cases like this one, but generally we recommend yo
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-08-01-react-v-16-4-2.md
+++ b/content/blog/2018-08-01-react-v-16-4-2.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-10-01-create-react-app-v2.md
+++ b/content/blog/2018-10-01-create-react-app-v2.md
@@ -5,7 +5,7 @@ author: [timer, gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-10-23-react-v-16-6.md
+++ b/content/blog/2018-10-23-react-v-16-6.md
@@ -5,7 +5,7 @@ author: [sebmarkbage]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-11-13-react-conf-recap.md
+++ b/content/blog/2018-11-13-react-conf-recap.md
@@ -5,7 +5,7 @@ author: [tomocchino]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-11-27-react-16-roadmap.md
+++ b/content/blog/2018-11-27-react-16-roadmap.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 
@@ -207,7 +207,7 @@ We started designing a new server renderer that supports Suspense (including wai
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2018-12-19-react-v-16-7.md
+++ b/content/blog/2018-12-19-react-v-16-7.md
@@ -5,7 +5,7 @@ author: [acdlite]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2019-02-06-react-v16.8.0.md
+++ b/content/blog/2019-02-06-react-v16.8.0.md
@@ -5,7 +5,7 @@ author: [gaearon]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2019-02-23-is-react-translated-yet.md
+++ b/content/blog/2019-02-23-is-react-translated-yet.md
@@ -5,7 +5,7 @@ author: [tesseralis]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2019-08-08-react-v16.9.0.md
+++ b/content/blog/2019-08-08-react-v16.9.0.md
@@ -5,7 +5,7 @@ author: [gaearon, bvaughn]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2019-10-22-react-release-channels.md
+++ b/content/blog/2019-10-22-react-release-channels.md
@@ -5,7 +5,7 @@ author: [acdlite]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2019-11-06-building-great-user-experiences-with-concurrent-mode-and-suspense.md
+++ b/content/blog/2019-11-06-building-great-user-experiences-with-concurrent-mode-and-suspense.md
@@ -5,7 +5,7 @@ author: [josephsavona]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2020-02-26-react-v16.13.0.md
+++ b/content/blog/2020-02-26-react-v16.13.0.md
@@ -7,7 +7,7 @@ redirect_from:
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2020-08-10-react-v17-rc.md
+++ b/content/blog/2020-08-10-react-v17-rc.md
@@ -5,7 +5,7 @@ author: [gaearon,rachelnabors]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2020-09-22-introducing-the-new-jsx-transform.md
+++ b/content/blog/2020-09-22-introducing-the-new-jsx-transform.md
@@ -5,7 +5,7 @@ author: [lunaruan]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2020-10-20-react-v17.md
+++ b/content/blog/2020-10-20-react-v17.md
@@ -5,7 +5,7 @@ author: [gaearon,rachelnabors]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2020-12-21-data-fetching-with-react-server-components.md
+++ b/content/blog/2020-12-21-data-fetching-with-react-server-components.md
@@ -5,7 +5,7 @@ author: [gaearon,laurentan,josephsavona,sebmarkbage]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2021-06-08-the-plan-for-react-18.md
+++ b/content/blog/2021-06-08-the-plan-for-react-18.md
@@ -5,7 +5,7 @@ author: [acdlite, bvaughn, abernathyca, gaearon, rachelnabors, rickhanlonii, seb
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2021-12-17-react-conf-2021-recap.md
+++ b/content/blog/2021-12-17-react-conf-2021-recap.md
@@ -5,7 +5,7 @@ author: [jtannady, rickhanlonii]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2022-03-08-react-18-upgrade-guide.md
+++ b/content/blog/2022-03-08-react-18-upgrade-guide.md
@@ -5,7 +5,7 @@ author: [rickhanlonii]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2022-03-29-react-v18.md
+++ b/content/blog/2022-03-29-react-v18.md
@@ -5,7 +5,7 @@ author: [reactteam]
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/blog/2022-06-15-react-labs-what-we-have-been-working-on-june-2022.md
+++ b/content/blog/2022-06-15-react-labs-what-we-have-been-working-on-june-2022.md
@@ -5,7 +5,7 @@ author: [acdlite,gaearon,kassens,josephsavona,joshcstory,laurentan,lunaruan,meng
 
 <div class="scary">
 
-> This blog site has been archived. Go to [react.dev/blog](https://react.dev/blog) to see the recent posts.
+> このブログはアーカイブされています。最新の記事は [ja.react.dev/blog](https://ja.react.dev/blog) でご覧ください。
 
 </div>
 

--- a/content/community/articles.md
+++ b/content/community/articles.md
@@ -8,7 +8,7 @@ permalink: community/articles.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 
 </div>
 

--- a/content/community/conferences.md
+++ b/content/community/conferences.md
@@ -10,9 +10,9 @@ redirect_from:
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> See the [Conferences](https://react.dev/community/conferences) page on the new site.
+> 新サイトの [React カンファレンス](https://ja.react.dev/community/conferences)を参照してください。
 >
 </div>
 

--- a/content/community/courses.md
+++ b/content/community/courses.md
@@ -9,7 +9,7 @@ permalink: community/courses.html
 <div class="scary">
 
 >
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 
 </div>
 

--- a/content/community/examples.md
+++ b/content/community/examples.md
@@ -8,7 +8,7 @@ permalink: community/examples.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 
 </div>
 

--- a/content/community/external-resources.md
+++ b/content/community/external-resources.md
@@ -8,7 +8,7 @@ permalink: community/external-resources.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 
 </div>
 

--- a/content/community/meetups.md
+++ b/content/community/meetups.md
@@ -8,9 +8,9 @@ permalink: community/meetups.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> See the [Meetups](https://react.dev/community/meetups) page on the new site.
+> 新サイトの [React ミーティング](https://ja.react.dev/community/meetups)を参照してください。
 >
 </div>
 

--- a/content/community/podcasts.md
+++ b/content/community/podcasts.md
@@ -8,7 +8,7 @@ permalink: community/podcasts.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 
 </div>
 

--- a/content/community/support.md
+++ b/content/community/support.md
@@ -11,9 +11,9 @@ redirect_from:
 <div class="scary">
 
 >
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> See the [Community](https://react.dev/community) resources on the new site.
+> 新サイトの[コミュニティ](https://ja.react.dev/community)リソースを参照してください。
 
 </div>
 

--- a/content/community/team.md
+++ b/content/community/team.md
@@ -9,9 +9,9 @@ permalink: community/team.html
 <div class="scary">
 
 >
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> See the [Team](https://react.dev/community/team) page on the new site.
+> 新サイトの[チーム紹介](https://ja.react.dev/community/team)ページを参照してください。
 
 </div>
 

--- a/content/community/videos.md
+++ b/content/community/videos.md
@@ -10,9 +10,9 @@ redirect_from:
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> See the [Videos](https://react.dev/community/videos) page on the new site.
+> 新サイトの [React 関連動画](https://ja.react.dev/community/videos)を参照してください。
 >
 </div>
 

--- a/content/docs/add-react-to-a-website.md
+++ b/content/docs/add-react-to-a-website.md
@@ -11,9 +11,9 @@ next: create-a-new-react-app.html
 <div class="scary">
 
 >
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> See [Add React to an Existing Project](https://react.dev/learn/add-react-to-an-existing-project) for the recommended ways to add React.
+> React を追加するためのおすすめの方法については、[既存プロジェクトに React を追加する](https://ja.react.dev/learn/add-react-to-an-existing-project)を参照してください。
 
 </div>
 

--- a/content/docs/cdn-links.md
+++ b/content/docs/cdn-links.md
@@ -9,9 +9,9 @@ next: release-channels.html
 <div class="scary">
 
 >
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> See [Add React to an Existing Project](https://react.dev/learn/add-react-to-an-existing-project) for the recommended ways to add React.
+> React を追加する推奨の方法については、[既存プロジェクトに React を追加する](https://ja.react.dev/learn/add-react-to-an-existing-project)を参照してください。
 
 </div>
 

--- a/content/docs/code-splitting.md
+++ b/content/docs/code-splitting.md
@@ -6,12 +6,12 @@ permalink: docs/code-splitting.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> These new documentation pages teach modern React and include live examples:
+> 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [`lazy`](https://react.dev/reference/react/lazy)
-> - [`<Suspense>`](https://react.dev/reference/react/Suspense)
+> - [`lazy`](https://ja.react.dev/reference/react/lazy)
+> - [`<Suspense>`](https://ja.react.dev/reference/react/Suspense)
 
 </div>
 

--- a/content/docs/components-and-props.md
+++ b/content/docs/components-and-props.md
@@ -18,14 +18,12 @@ next: state-and-lifecycle.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Your First Component](https://beta.reactjs.org/learn/your-first-component)
-> - [Passing Props to a Component](https://beta.reactjs.org/learn/passing-props-to-a-component)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [初めてのコンポーネント](https://ja.react.dev/learn/your-first-component)
+> - [コンポーネントに props を渡す](https://ja.react.dev/learn/passing-props-to-a-component)
 
 </div>
 

--- a/content/docs/composition-vs-inheritance.md
+++ b/content/docs/composition-vs-inheritance.md
@@ -10,7 +10,7 @@ next: thinking-in-react.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 
 </div>
 

--- a/content/docs/conditional-rendering.md
+++ b/content/docs/conditional-rendering.md
@@ -10,13 +10,11 @@ redirect_from:
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Conditional Rendering](https://beta.reactjs.org/learn/conditional-rendering)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [条件付きレンダー](https://ja.react.dev/learn/conditional-rendering)
 
 </div>
 

--- a/content/docs/context.md
+++ b/content/docs/context.md
@@ -6,14 +6,12 @@ permalink: docs/context.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Passing Data Deeply with Context](https://beta.reactjs.org/learn/passing-data-deeply-with-context)
-> - [`useContext`](https://beta.reactjs.org/reference/react/useContext)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [コンテクストで深くデータを受け渡す](https://ja.react.dev/learn/passing-data-deeply-with-context)
+> - [`useContext`](https://ja.react.dev/reference/react/useContext)
 
 </div>
 

--- a/content/docs/create-a-new-react-app.md
+++ b/content/docs/create-a-new-react-app.md
@@ -11,9 +11,9 @@ next: cdn-links.html
 <div class="scary">
 
 >
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> See [Start a New React Project](https://react.dev/learn/start-a-new-react-project) for the recommended ways to create an app.
+> アプリを作成する際のおすすめの方法については、[React プロジェクトを始める](https://ja.react.dev/learn/start-a-new-react-project)を参照してください。
 
 </div>
 

--- a/content/docs/error-boundaries.md
+++ b/content/docs/error-boundaries.md
@@ -6,11 +6,11 @@ permalink: docs/error-boundaries.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> These new documentation pages teach modern React:
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
 >
-> - [`React.Component`: Catching rendering errors with an error boundary](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)
+> - [`React.Component`: エラーバウンダリでレンダー中のエラーをキャッチする](https://ja.react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary)
 
 </div>
 

--- a/content/docs/forms.md
+++ b/content/docs/forms.md
@@ -11,15 +11,13 @@ redirect_from:
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [`<input>`](https://beta.reactjs.org/reference/react-dom/components/input)
-> - [`<select>`](https://beta.reactjs.org/reference/react-dom/components/select)
-> - [`<textarea>`](https://beta.reactjs.org/reference/react-dom/components/textarea)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [`<input>`](https://ja.react.dev/reference/react-dom/components/input)
+> - [`<select>`](https://ja.react.dev/reference/react-dom/components/select)
+> - [`<textarea>`](https://ja.react.dev/reference/react-dom/components/textarea)
 
 </div>
 

--- a/content/docs/forwarding-refs.md
+++ b/content/docs/forwarding-refs.md
@@ -6,14 +6,12 @@ permalink: docs/forwarding-refs.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Manipulating the DOM with Refs](https://beta.reactjs.org/learn/manipulating-the-dom-with-refs)
-> - [`forwardRef`](https://beta.reactjs.org/reference/react/forwardRef)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [ref で DOM を操作する](https://ja.react.dev/learn/manipulating-the-dom-with-refs)
+> - [`forwardRef`](https://ja.react.dev/reference/react/forwardRef)
 
 </div>
 

--- a/content/docs/fragments.md
+++ b/content/docs/fragments.md
@@ -6,11 +6,11 @@ permalink: docs/fragments.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> These new documentation pages teach modern React:
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
 >
-> - [`<Fragment>`](https://react.dev/reference/react/Fragment)
+> - [`<Fragment>`](https://ja.react.dev/reference/react/Fragment)
 
 </div>
 

--- a/content/docs/getting-started.md
+++ b/content/docs/getting-started.md
@@ -20,11 +20,9 @@ redirect_from:
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。
 > 
-> 新しい[クイックスタートガイド](https://beta.reactjs.org/learn)では最新の React がライブサンプル付きで学べます。
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> 新しい[クイックスタートガイド](https://ja.react.dev/learn)では最新の React がライブサンプル付きで学べます。
 
 </div>
 

--- a/content/docs/handling-events.md
+++ b/content/docs/handling-events.md
@@ -10,13 +10,11 @@ redirect_from:
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Responding to Events](https://beta.reactjs.org/learn/responding-to-events)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [イベントへの応答](https://ja.react.dev/learn/responding-to-events)
 
 </div>
 

--- a/content/docs/hello-world.md
+++ b/content/docs/hello-world.md
@@ -9,9 +9,9 @@ next: introducing-jsx.html
 <div class="scary">
 
 >
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> See [Quick Start](https://react.dev/learn) for an introduction to React.
+> React の導入については新しい[クイックスタート](https://ja.react.dev/learn)を参照してください。
 
 </div>
 

--- a/content/docs/higher-order-components.md
+++ b/content/docs/higher-order-components.md
@@ -6,9 +6,9 @@ permalink: docs/higher-order-components.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> Higher-order components are not commonly used in modern React code.
+> 高階コンポーネントはモダンな React コードではあまり使われなくなりました。
 
 </div>
 

--- a/content/docs/hooks-custom.md
+++ b/content/docs/hooks-custom.md
@@ -8,13 +8,11 @@ prev: hooks-rules.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Reusing Logic with Custom Hooks](https://beta.reactjs.org/learn/reusing-logic-with-custom-hooks)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [カスタムフックでロジックを再利用する](https://ja.react.dev/learn/reusing-logic-with-custom-hooks)
 
 </div>
 

--- a/content/docs/hooks-effect.md
+++ b/content/docs/hooks-effect.md
@@ -8,15 +8,13 @@ prev: hooks-state.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Synchronizing with Effects](https://beta.reactjs.org/learn/synchronizing-with-effects)
-> - [You Might Not Need an Effect](https://beta.reactjs.org/learn/you-might-not-need-an-effect)
-> - [`useEffect`](https://beta.reactjs.org/reference/react/useEffect)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [エフェクトを使って同期を行う](https://ja.react.dev/learn/synchronizing-with-effects)
+> - [エフェクトは必要ないかもしれない](https://ja.react.dev/learn/you-might-not-need-an-effect)
+> - [`useEffect`](https://ja.react.dev/reference/react/useEffect)
 
 </div>
 

--- a/content/docs/hooks-faq.md
+++ b/content/docs/hooks-faq.md
@@ -7,9 +7,9 @@ prev: hooks-reference.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> The new documentation pages teaches React with Hooks.
+> 新しいドキュメントではフックを使って React が学べます。
 
 </div>
 

--- a/content/docs/hooks-intro.md
+++ b/content/docs/hooks-intro.md
@@ -7,13 +7,13 @@ next: hooks-overview.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> These new documentation pages teach React with Hooks:
+> 以下の新しいドキュメントでフックを用いた最新の React の使い方が学べます。
 >
-> - [Quick Start](https://react.dev/learn)
-> - [Tutorial](https://react.dev/learn/tutorial-tic-tac-toe)
-> - [`react`: Hooks](https://react.dev/reference/react)
+> - [クイックスタート](https://ja.react.dev/learn)
+> - [チュートリアル](https://ja.react.dev/learn/tutorial-tic-tac-toe)
+> - [`react`: フック](https://ja.react.dev/reference/react)
 
 </div>
 

--- a/content/docs/hooks-overview.md
+++ b/content/docs/hooks-overview.md
@@ -8,13 +8,13 @@ prev: hooks-intro.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> These new documentation pages teach React with Hooks:
+> 以下の新しいドキュメントでフックを用いた最新の React の使い方が学べます。
 >
-> - [Quick Start](https://react.dev/learn)
-> - [Tutorial](https://react.dev/learn/tutorial-tic-tac-toe)
-> - [`react`: Hooks](https://react.dev/reference/react)
+> - [クイックスタート](https://ja.react.dev/learn)
+> - [チュートリアル](https://ja.react.dev/learn/tutorial-tic-tac-toe)
+> - [`react`: フック](https://ja.react.dev/reference/react)
 
 </div>
 

--- a/content/docs/hooks-reference.md
+++ b/content/docs/hooks-reference.md
@@ -8,11 +8,11 @@ next: hooks-faq.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
+> 
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
 >
-> These new documentation pages teach modern React:
->
-> - [`react`: Hooks](https://react.dev/reference/react)
+> - [`react`: フック](https://ja.react.dev/reference/react)
 
 </div>
 

--- a/content/docs/hooks-state.md
+++ b/content/docs/hooks-state.md
@@ -8,14 +8,12 @@ prev: hooks-overview.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [State: A Component's Memory](https://beta.reactjs.org/learn/state-a-components-memory)
-> - [`useState`](https://beta.reactjs.org/reference/react/useState)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [state：コンポーネントのメモリ](https://ja.react.dev/learn/state-a-components-memory)
+> - [`useState`](https://ja.react.dev/reference/react/useState)
 
 </div>
 

--- a/content/docs/integrating-with-other-libraries.md
+++ b/content/docs/integrating-with-other-libraries.md
@@ -6,14 +6,14 @@ permalink: docs/integrating-with-other-libraries.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> These new documentation pages teach modern React:
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
 >
-> - [`useSyncExternalStore`: Subscribing to an external store 
-](https://react.dev/reference/react/useSyncExternalStore#subscribing-to-an-external-store)
-> - [`createPortal`: Rendering React components into non-React DOM nodes 
-](https://react.dev/reference/react-dom/createPortal#rendering-react-components-into-non-react-dom-nodes)
+> - [`useSyncExternalStore`: 外部ストアへのサブスクライブ
+](https://ja.react.dev/reference/react/useSyncExternalStore#subscribing-to-an-external-store)
+> - [`createPortal`: 非 React DOM ノードに React コンポーネントをレンダー
+](https://ja.react.dev/reference/react-dom/createPortal#rendering-react-components-into-non-react-dom-nodes)
 
 </div>
 

--- a/content/docs/introducing-jsx.md
+++ b/content/docs/introducing-jsx.md
@@ -8,14 +8,12 @@ next: rendering-elements.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Writing Markup with JSX](https://beta.reactjs.org/learn/writing-markup-with-jsx)
-> - [JavaScript in JSX with Curly Braces](https://beta.reactjs.org/learn/javascript-in-jsx-with-curly-braces)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [JSX でマークアップを記述する](https://ja.react.dev/learn/writing-markup-with-jsx)
+> - [JSX に波括弧で JavaScript を含める](https://ja.react.dev/learn/javascript-in-jsx-with-curly-braces)
 
 </div>
 

--- a/content/docs/jsx-in-depth.md
+++ b/content/docs/jsx-in-depth.md
@@ -15,7 +15,7 @@ redirect_from:
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 
 </div>
 

--- a/content/docs/lifting-state-up.md
+++ b/content/docs/lifting-state-up.md
@@ -11,13 +11,11 @@ redirect_from:
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Sharing State Between Components](https://beta.reactjs.org/learn/sharing-state-between-components)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [コンポーネント間で state を共有する](https://ja.react.dev/learn/sharing-state-between-components)
 
 </div>
 

--- a/content/docs/lists-and-keys.md
+++ b/content/docs/lists-and-keys.md
@@ -8,13 +8,11 @@ next: forms.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Rendering Lists](https://beta.reactjs.org/learn/rendering-lists)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [リストのレンダー](https://ja.react.dev/learn/rendering-lists)
 
 </div>
 

--- a/content/docs/optimizing-performance.md
+++ b/content/docs/optimizing-performance.md
@@ -8,12 +8,12 @@ redirect_from:
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> These new documentation pages teach modern React:
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
 >
-> - [`memo`: Skipping re-rendering when props are unchanged
-](https://react.dev/reference/react/memo#skipping-re-rendering-when-props-are-unchanged)
+> - [`memo`: props が変更されていない場合に再レンダーをスキップする
+](https://ja.react.dev/reference/react/memo#skipping-re-rendering-when-props-are-unchanged)
 
 </div>
 

--- a/content/docs/portals.md
+++ b/content/docs/portals.md
@@ -6,13 +6,11 @@ permalink: docs/portals.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [`createPortal`](https://beta.reactjs.org/reference/react-dom/createPortal)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [`createPortal`](https://ja.react.dev/reference/react-dom/createPortal)
 
 </div>
 

--- a/content/docs/react-without-es6.md
+++ b/content/docs/react-without-es6.md
@@ -6,7 +6,7 @@ permalink: docs/react-without-es6.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 
 </div>
 

--- a/content/docs/react-without-jsx.md
+++ b/content/docs/react-without-jsx.md
@@ -6,7 +6,7 @@ permalink: docs/react-without-jsx.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 
 </div>
 

--- a/content/docs/reconciliation.md
+++ b/content/docs/reconciliation.md
@@ -6,13 +6,11 @@ permalink: docs/reconciliation.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Preserving and Resetting State](https://beta.reactjs.org/learn/preserving-and-resetting-state)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [state の保持とリセット](https://ja.react.dev/learn/preserving-and-resetting-state)
 
 </div>
 

--- a/content/docs/reference-dom-elements.md
+++ b/content/docs/reference-dom-elements.md
@@ -16,18 +16,16 @@ redirect_from:
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Common components (e.g. `<div>`)](https://beta.reactjs.org/reference/react-dom/components/common)
-> - [`<input>`](https://beta.reactjs.org/reference/react-dom/components/input)
-> - [`<option>`](https://beta.reactjs.org/reference/react-dom/components/option)
-> - [`<progress>`](https://beta.reactjs.org/reference/react-dom/components/progress)
-> - [`<select>`](https://beta.reactjs.org/reference/react-dom/components/select)
-> - [`<textarea>`](https://beta.reactjs.org/reference/react-dom/components/textarea)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [Common components (e.g. `<div>`)](https://ja.react.dev/reference/react-dom/components/common)
+> - [`<input>`](https://ja.react.dev/reference/react-dom/components/input)
+> - [`<option>`](https://ja.react.dev/reference/react-dom/components/option)
+> - [`<progress>`](https://ja.react.dev/reference/react-dom/components/progress)
+> - [`<select>`](https://ja.react.dev/reference/react-dom/components/select)
+> - [`<textarea>`](https://ja.react.dev/reference/react-dom/components/textarea)
 
 </div>
 

--- a/content/docs/reference-events.md
+++ b/content/docs/reference-events.md
@@ -8,13 +8,11 @@ category: Reference
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [Common components (e.g. `<div>`)](https://beta.reactjs.org/reference/react-dom/components/common)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [&lt;div&gt; などの一般的なコンポーネント](https://ja.react.dev/reference/react-dom/components/common)
 
 </div>
 

--- a/content/docs/reference-profiler.md
+++ b/content/docs/reference-profiler.md
@@ -8,11 +8,11 @@ permalink: docs/profiler.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> These new documentation pages teach modern React:
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
 >
-> - [`<Profiler>`](https://react.dev/reference/react/Profiler)
+> - [`<Profiler>`](https://ja.react.dev/reference/react/Profiler)
 
 </div>
 

--- a/content/docs/reference-react-component.md
+++ b/content/docs/reference-react-component.md
@@ -17,9 +17,11 @@ redirect_from:
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください：[`Component`](https://beta.reactjs.org/reference/react/Component)
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
+>
+> [React.Component](https://ja.react.dev/reference/react/Component)
 
 </div>
 

--- a/content/docs/reference-react-dom-client.md
+++ b/content/docs/reference-react-dom-client.md
@@ -8,11 +8,11 @@ permalink: docs/react-dom-client.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
+> 
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
 >
-> These new documentation pages teach modern React:
->
-> - [`react-dom`: Client APIs](https://react.dev/reference/react-dom/client)
+> - [`react-dom`: クライアント用 API](https://ja.react.dev/reference/react-dom/client)
 
 </div>
 

--- a/content/docs/reference-react-dom-server.md
+++ b/content/docs/reference-react-dom-server.md
@@ -8,11 +8,11 @@ permalink: docs/react-dom-server.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
+> 
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
 >
-> These new documentation pages teach modern React:
->
-> - [`react-dom`: Server APIs](https://react.dev/reference/react-dom/server)
+> - [`react-dom`: サーバ用 API](https://react.dev/reference/react-dom/server)
 
 </div>
 

--- a/content/docs/reference-react-dom.md
+++ b/content/docs/reference-react-dom.md
@@ -8,14 +8,14 @@ permalink: docs/react-dom.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
+> 
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
 >
-> These new documentation pages teach modern React:
->
-> - [`react-dom`: Components](https://react.dev/reference/react-dom/components)
-> - [`react-dom`: APIs](https://react.dev/reference/react-dom)
-> - [`react-dom`: Client APIs](https://react.dev/reference/react-dom/client)
-> - [`react-dom`: Server APIs](https://react.dev/reference/react-dom/server)
+> - [`react-dom`: コンポーネント](https://ja.react.dev/reference/react-dom/components)
+> - [`react-dom`: API](https://ja.react.dev/reference/react-dom)
+> - [`react-dom`: クライアント用 API](https://ja.react.dev/reference/react-dom/client)
+> - [`react-dom`: サーバ用 API](https://ja.react.dev/reference/react-dom/server)
 
 </div>
 

--- a/content/docs/reference-react.md
+++ b/content/docs/reference-react.md
@@ -15,14 +15,14 @@ redirect_from:
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
+> 
+> 以下の新しいドキュメントで最新の React の使い方が学べます。
 >
-> These new documentation pages teach modern React:
->
-> - [`react`: Components](https://react.dev/reference/react/components)
-> - [`react`: Hooks](https://react.dev/reference/react/)
-> - [`react`: APIs](https://react.dev/reference/react/apis)
-> - [`react`: Legacy APIs](https://react.dev/reference/react/legacy)
+> - [`react`: コンポーネント](https://ja.react.dev/reference/react/components)
+> - [`react`: フック](https://ja.react.dev/reference/react/)
+> - [`react`: API](https://ja.react.dev/reference/react/apis)
+> - [`react`: レガシー API](https://ja.react.dev/reference/react/legacy)
 
 </div>
 

--- a/content/docs/refs-and-the-dom.md
+++ b/content/docs/refs-and-the-dom.md
@@ -13,14 +13,14 @@ redirect_from:
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> - [Referencing Values with Refs](https://beta.reactjs.org/learn/referencing-values-with-refs)
-> - [Manipulating the DOM with Refs](https://beta.reactjs.org/learn/manipulating-the-dom-with-refs)
-> - [`useRef`](https://beta.reactjs.org/reference/react/useRef)
-> - [`forwardRef`](https://beta.reactjs.org/reference/react/forwardRef)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
+> 
+> - [ref で値を参照する](https://ja.react.dev/learn/referencing-values-with-refs)
+> - [ref で DOM を操作する](https://ja.react.dev/learn/manipulating-the-dom-with-refs)
+> - [`useRef`](https://ja.react.dev/reference/react/useRef)
+> - [`forwardRef`](https://ja.react.dev/reference/react/forwardRef)
 
 </div>
 

--- a/content/docs/release-channels.md
+++ b/content/docs/release-channels.md
@@ -11,9 +11,9 @@ next: hello-world.html
 <div class="scary">
 
 >
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> See [Versioning Policy](https://react.dev/community/versioning-policy) to learn about the React release channels.
+> React のリリースチャンネルについては[バージョニングポリシー](https://ja.react.dev/community/versioning-policy)を参照してください。
 
 </div>
 

--- a/content/docs/render-props.md
+++ b/content/docs/render-props.md
@@ -6,10 +6,10 @@ permalink: docs/render-props.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> Render props are used in modern React, but aren't very common.  
-> For many cases, they have been replaced by [custom Hooks](https://react.dev/learn/reusing-logic-with-custom-hooks).
+> レンダープロップはモダンな React でも使われますが、あまり一般的ではなくなっています。
+> 多くのユースケースでは、[カスタムフック](https://ja.react.dev/learn/reusing-logic-with-custom-hooks)に置き換わりました。
 
 </div>
 

--- a/content/docs/rendering-elements.md
+++ b/content/docs/rendering-elements.md
@@ -11,12 +11,12 @@ next: components-and-props.html
 <div class="scary">
 
 >
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> These new documentation pages teach how to write JSX and show it on an HTML page:
+> 以下の新しいドキュメントで JSX の書き方や HTML ページへの表示方法が学べます。
 >
-> - [Writing Markup with JSX](https://react.dev/learn/writing-markup-with-jsx)
-> - [Add React to an Existing Project](https://react.dev/learn/add-react-to-an-existing-project#step-2-render-react-components-anywhere-on-the-page)
+> - [JSX でマークアップを記述する](https://ja.react.dev/learn/writing-markup-with-jsx)
+> - [既存プロジェクトに React を追加する](https://ja.react.dev/learn/add-react-to-an-existing-project#step-2-render-react-components-anywhere-on-the-page)
 
 </div>
 

--- a/content/docs/state-and-lifecycle.md
+++ b/content/docs/state-and-lifecycle.md
@@ -10,14 +10,12 @@ next: handling-events.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [State: A Component's Memory](https://beta.reactjs.org/learn/state-a-components-memory)
-> - [Synchronizing with Effects](https://beta.reactjs.org/learn/synchronizing-with-effects)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [state：コンポーネントのメモリ](https://ja.react.dev/learn/state-a-components-memory)
+> - [エフェクトを使って同期を行う](https://ja.react.dev/learn/synchronizing-with-effects)
 
 </div>
 

--- a/content/docs/static-type-checking.md
+++ b/content/docs/static-type-checking.md
@@ -6,9 +6,9 @@ permalink: docs/static-type-checking.html
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> Check out [React TypeScript cheatsheet](https://react-typescript-cheatsheet.netlify.app/) for how to use React with TypeScript.
+> [React TypeScript cheatsheet](https://react-typescript-cheatsheet.netlify.app/) で TypeScript を使って React を書く方法が学べます。
 
 </div>
 

--- a/content/docs/strict-mode.md
+++ b/content/docs/strict-mode.md
@@ -6,13 +6,11 @@ permalink: docs/strict-mode.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [`StrictMode`](https://beta.reactjs.org/reference/react/StrictMode)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [`StrictMode`](https://ja.react.dev/reference/react/StrictMode)
 
 </div>
 

--- a/content/docs/thinking-in-react.md
+++ b/content/docs/thinking-in-react.md
@@ -10,11 +10,9 @@ prev: composition-vs-inheritance.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> [Thinking in React](https://beta.reactjs.org/learn/thinking-in-react) の更新版では最新の React の使い方がライブサンプル付きで学べます。
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> 新しいバージョンの[React の流儀](https://ja.react.dev/learn/thinking-in-react)では、最新の React の使い方がライブサンプル付きで学べます。
 
 </div>
 

--- a/content/docs/typechecking-with-proptypes.md
+++ b/content/docs/typechecking-with-proptypes.md
@@ -8,9 +8,9 @@ redirect_from:
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> PropTypes aren't commonly used in modern React. Use TypeScript for static type checking.
+> PropTypes はモダンな React ではあまり使われなくなっています。静的型チェックには TypeScript を利用してください。
 
 </div>
 

--- a/content/docs/uncontrolled-components.md
+++ b/content/docs/uncontrolled-components.md
@@ -6,15 +6,13 @@ permalink: docs/uncontrolled-components.html
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
 > 以下の新しいドキュメントで最新の React の使い方がライブサンプル付きで学べます。
 >
-> - [`<input>`](https://beta.reactjs.org/reference/react-dom/components/input)
-> - [`<select>`](https://beta.reactjs.org/reference/react-dom/components/select)
-> - [`<textarea>`](https://beta.reactjs.org/reference/react-dom/components/textarea)
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> - [`<input>`](https://ja.react.dev/reference/react-dom/components/input)
+> - [`<select>`](https://ja.react.dev/reference/react-dom/components/select)
+> - [`<textarea>`](https://ja.react.dev/reference/react-dom/components/textarea)
 
 </div>
 

--- a/content/docs/web-components.md
+++ b/content/docs/web-components.md
@@ -8,9 +8,9 @@ redirect_from:
 
 <div class="scary">
 
-> These docs are old and won't be updated. Go to [react.dev](https://react.dev/) for the new React docs.
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 >
-> See [Custom HTML elements](https://react.dev/reference/react-dom/components#custom-html-elements) in the new docs.
+> 新ドキュメントの[カスタム HTML 要素](https://ja.react.dev/reference/react-dom/components#custom-html-elements)を参照してください。
 >
 </div>
 

--- a/content/tutorial/tutorial.md
+++ b/content/tutorial/tutorial.md
@@ -14,11 +14,9 @@ redirect_from:
 
 <div class="scary">
 
-> 新しい React ドキュメントをお試しください。
+> この記事は古くなっており、今後更新されません。新しい React ドキュメントである [ja.react.dev](https://ja.react.dev) をご利用ください。
 > 
-> [チュートリアル](https://beta.reactjs.org/learn/tutorial-tic-tac-toe) の更新版では最新の React の使い方がライブサンプル付きで学べます。
->
-> まもなく新しいドキュメントがリリースされ、このページはアーカイブされる予定です。[フィードバックを送る](https://github.com/reactjs/reactjs.org/issues/3308)
+> 新しくなった[チュートリアル](https://ja.react.dev/learn/tutorial-tic-tac-toe)では最新の React の使い方がライブサンプル付きで学べます。
 
 </div>
 

--- a/src/components/SocialBanner/SocialBanner.js
+++ b/src/components/SocialBanner/SocialBanner.js
@@ -16,7 +16,7 @@ const linkProps = {
 };
 
 const bannerText = 'このサイトの更新は終了しました。';
-const bannerLink = 'ja.react.dev (翻訳中) へ';
+const bannerLink = 'ja.react.dev へ';
 
 export default function SocialBanner() {
   return (


### PR DESCRIPTION
旧サイト側へのPRです。

- 英語版へのリンク（ベータとなっているのも含む）をすべて ja.react.dev のページへのリンクに置き換えました。
- 翻訳されていなかった警告も全部日本語にしました。