### PR TITLE
Redirect some external links to Japanese versions

### DIFF
--- a/src/components/MDX/Link.tsx
+++ b/src/components/MDX/Link.tsx
@@ -29,6 +29,16 @@ function Link({
     // eslint-disable-next-line jsx-a11y/anchor-has-content
     return <a href={href} className={className} {...props} />;
   }
+
+  // Tweak external links (added by ja.react.dev team)
+  href = href
+    .replace(
+      'https://developer.mozilla.org/en-US/',
+      'https://developer.mozilla.org/'
+    )
+    .replace('https://reactjs.org/', 'https://ja.reactjs.org/')
+    .replace('https://legacy.reactjs.org/', 'https://ja.legacy.reactjs.org/');
+
   return (
     <>
       {href.startsWith('https://') ? (


### PR DESCRIPTION
MDN のリンク先が英語版になっている問題を JavaScript のソースコードベースで解消します。`Link` 関数は MDX の `[]()` 構文の[実装を置き換える](https://mdxjs.com/table-of-components/)ためのコンポーネントです。その部分に以下のようなコードを追加します。

```ts
href = href
  .replace(
    'https://developer.mozilla.org/en-US/',
    'https://developer.mozilla.org/'
  )
  .replace('https://reactjs.org/', 'https://ja.reactjs.org/')
  .replace('https://legacy.reactjs.org/', 'https://ja.legacy.reactjs.org/');
```

MDN の URL から `en-US` を取り除くことで、基本言語が日本語になっているブラウザからのアクセス、かつ日本語記事が既に存在する場合、自動的にそちらにリダイレクトされるようになります。

問題点は 2 個あります。

- また MDN の方は我々がやっているような見出し ID の固定をやっていないため、ページ言語が変わることで見出し ID も変わってしまいます。ただし記事内見出しへのリンクはそもそも数が少なく、かつ英語版の時点で既に大半が壊れているようなので、こちらの対処は行わないでいいかなと思います。

- MDN 側でまだ和訳が記事の場合、自動的に英語版にフォールバックしてくれることが多いようなのですが、一部、以下のようなエラーページが表示されることもあります。条件は不明です。

  <img width="901" alt="image" src="https://github.com/reactjs/ja.react.dev/assets/7779406/3bf2b2d0-17a7-46e2-b879-35533ed0b7a6">

  ただしこのパターンになる数は非常に少ないようですし、英語記事へのリンクも表示されはしますし、将来は MDN 側で直してくれるかもしれませんので、とりあえずこのままで良いかなと思います。