### PR TITLE
fix: 「ref で DOM を操作する」ページで画像が表示できていない事象を解消

### DIFF
--- a/src/content/learn/manipulating-the-dom-with-refs.md
+++ b/src/content/learn/manipulating-the-dom-with-refs.md
@@ -124,35 +124,35 @@ export default function CatFriends() {
     <>
       <nav>
         <button onClick={handleScrollToFirstCat}>
-          Tom
+          Neo
         </button>
         <button onClick={handleScrollToSecondCat}>
-          Maru
+          Millie
         </button>
         <button onClick={handleScrollToThirdCat}>
-          Jellylorum
+          Bella
         </button>
       </nav>
       <div>
         <ul>
           <li>
             <img
-              src="https://placekitten.com/g/200/200"
-              alt="Tom"
+              src="https://placecats.com/neo/300/200"
+              alt="Neo"
               ref={firstCatRef}
             />
           </li>
           <li>
             <img
-              src="https://placekitten.com/g/300/200"
-              alt="Maru"
+              src="https://placecats.com/millie/200/200"
+              alt="Millie"
               ref={secondCatRef}
             />
           </li>
           <li>
             <img
-              src="https://placekitten.com/g/250/200"
-              alt="Jellylorum"
+              src="https://placecats.com/bella/199/200"
+              alt="Bella"
               ref={thirdCatRef}
             />
           </li>


### PR DESCRIPTION
## 作業内容

- 画像取得先の https://placekitten.com が521エラーで画像をレスポンスできない状態になっており、対象ページで画像が表示されない（結果としてrefフックの動作確認ができない）事象が発生していたためこれに対応。
-  [オリジナルページ](https://react.dev/learn/manipulating-the-dom-with-refs) では https://placecats.com から画像取得するようになっていたため、日本語版ページでも同様に修正。

## 対象ページ

https://ja.react.dev/learn/manipulating-the-dom-with-refs 

<details><summary> 📸 作業後の状況</summary>
<p>



</p>
</details> 