### PR TITLE
updates href according to latest doc

### DIFF
--- a/src/content/reference/rsc/server-components.md
+++ b/src/content/reference/rsc/server-components.md
@@ -4,7 +4,7 @@ title: サーバコンポーネント
 
 <RSC>
 
-サーバコンポーネントは [React Server Components](/learn/start-a-new-react-project#bleeding-edge-react-frameworks) 用の機能です。
+サーバコンポーネントは [React Server Components](/learn/creating-a-react-app#full-stack-frameworks) 用の機能です。
 
 </RSC>
 


### PR DESCRIPTION
https://ja.react.dev/reference/rsc/server-components の以下のリンク先が存在しないリンク先になっています。

> サーバコンポーネントは [React Server Components](https://ja.react.dev/learn/start-a-new-react-project#bleeding-edge-react-frameworks) 用の機能です。

https://react.dev/reference/rsc/server-components の同じリンクの`href`に合わせて修正しました。

<!--

日本語版 (ja.react.dev) リポジトリでのPR/Issueは、日本語版固有の問題
（翻訳や日本語版独自機能に関係するもの）のみ受け付けます。

全言語に関わる問題や改善（英語部分のスペルミス、コードサンプルの修正、ビルドシステム改善等）
については、英語版リポジトリ (https://github.com/reactjs/react.dev)
でPR/Issueを作成してください。

日本語版の作業フローについては以下を参照してください。
https://github.com/reactjs/ja.react.dev/wiki

-->
